### PR TITLE
Normalize URLs before comparing them

### DIFF
--- a/descriptions/text.mdx
+++ b/descriptions/text.mdx
@@ -37,6 +37,10 @@ extension automatically filters the result to Amazon-sold products only.
 
 ## Changelog
 
+### v1.1.1
+
+Fix an infinite redirection on some sites when applying another shopping filter.
+
 ### v1.1.0
 
 Support various regions for Amazon, Newegg, Target, and Walmart.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "Sold by Official",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "Sold by Official",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@8hobbies/utils": "^4.2.0"
@@ -26,7 +26,7 @@
         "sass-embedded": "^1.83.1",
         "typescript": "~5.7.3",
         "typescript-eslint": "^8.19.1",
-        "vite": "^6.0.7",
+        "vite": "^6.0.9",
         "vite-plugin-web-extension": "^4.4.3",
         "vitest": "^2.1.6",
         "web-ext": "^8.3.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "Sold by Official",
   "description": "Shop products sold by e-commerce websites themselves only",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "scripts": {
     "compile": "tsc",

--- a/src/background.ts
+++ b/src/background.ts
@@ -21,6 +21,7 @@ import {
   getUpdatedBadgeText,
   toggleExtensionOnCurrentSite,
 } from "./main";
+import { areUrlsEqual } from "./utils";
 import { builtinSiteData } from "./site_data";
 
 chrome.runtime.onInstalled.addListener(async (details) => {
@@ -46,7 +47,7 @@ async function updateToNewUrlCallback(
   }
 
   const url = await generateActivatingUrl(details.url, builtinSiteData);
-  if (url === null || url === details.url) {
+  if (url === null || areUrlsEqual(url, details.url)) {
     return;
   }
   await chrome.tabs.update(details.tabId, {
@@ -94,7 +95,7 @@ chrome.action.onClicked.addListener(async (tab) => {
   }
 
   const url = await toggleExtensionOnCurrentSite(tab.url, builtinSiteData);
-  if (url === null || url === tab.url) {
+  if (url === null || areUrlsEqual(url, tab.url)) {
     return;
   }
 

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -23,6 +23,7 @@ import {
   getUpdatedBadgeText,
   toggleExtensionOnCurrentSite,
 } from "./main";
+import { areUrlsEqual } from "./utils";
 
 describe("generate Url", () => {
   const activating1Result = "https://example.com/?result=activated" as const;
@@ -298,6 +299,34 @@ describe("builtin sitedata", () => {
           builtinSiteData,
         ),
       ).toBe(`https://www.walmart.${tld}/search`);
+    });
+  }
+});
+
+describe("URL Comparison", () => {
+  for (const [name, url1, url2] of [
+    ["same URL", "https://example.com/a?a", "https://example.com/a?a"],
+    [
+      "different querystring but same after normalization",
+      "https://example.com/a?a=",
+      "https://example.com/a?a",
+    ],
+  ] as const) {
+    test(`Equal URLs: ${name}`, () => {
+      expect(areUrlsEqual(url1, url2));
+    });
+  }
+
+  for (const [name, url1, url2] of [
+    [
+      "different querystring",
+      "https://example.com/a?a&b",
+      "https://example.com/a?a",
+    ],
+    ["different path", "https://example.com/b?a", "https://example.com/a?a"],
+  ] as const) {
+    test(`Unequal URLs: ${name}`, () => {
+      expect(areUrlsEqual(url1, url2));
     });
   }
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -53,3 +53,13 @@ export function removeUrlParam(url: string, paramKey: string): string | null {
   parsedUrl.searchParams.delete(paramKey);
   return parsedUrl.toString();
 }
+
+/** Are the two URLs equal? */
+export function areUrlsEqual(url1: string, url2: string): boolean {
+  const urls = [new URL(url1), new URL(url2)];
+  // Normalize the query strings.
+  for (const url of urls) {
+    url.search = new URLSearchParams(url.search).toString();
+  }
+  return urls[0].toString() === urls[1].toString();
+}


### PR DESCRIPTION
Some sites may redirect user to a non-normalized URL, which may cause URL comparison to dysfunction.