### PR TITLE
Preserve other filters on Amazon

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -180,22 +180,51 @@ describe("builtin sitedata", () => {
   ] as const) {
     const amazonSiteId = `Amazon.${tld}` as const;
 
-    for (const [name, url] of [
-      ["question mark ending", `https://www.amazon.${tld}/s?`],
-      ["slash ending", `https://www.amazon.${tld}/s/`],
+    for (const [name, url, expected] of [
+      [
+        "question mark ending",
+        `https://www.amazon.${tld}/s?`,
+        `https://www.amazon.${tld}/s?${siteParams[amazonSiteId].key}=${encodeURIComponent(siteParams[amazonSiteId].value)}`,
+      ],
+      [
+        "slash ending",
+        `https://www.amazon.${tld}/s/`,
+        `https://www.amazon.${tld}/s/?${siteParams[amazonSiteId].key}=${encodeURIComponent(siteParams[amazonSiteId].value)}`,
+      ],
       [
         "question mark ending with subcategory",
-        `https://www.amazon.${tld}/subcategory/s/`,
+        `https://www.amazon.${tld}/subcategory/s?`,
+        `https://www.amazon.${tld}/subcategory/s?${siteParams[amazonSiteId].key}=${encodeURIComponent(siteParams[amazonSiteId].value)}`,
       ],
       [
         "slash ending with subcategory",
-        `https://www.amazon.${tld}/subcategory/s?`,
+        `https://www.amazon.${tld}/subcategory/s/`,
+        `https://www.amazon.${tld}/subcategory/s/?${siteParams[amazonSiteId].key}=${encodeURIComponent(siteParams[amazonSiteId].value)}`,
+      ],
+      [
+        "params only contain the Amazon seller key-value pair",
+        `https://www.amazon.${tld}/subcategory/s?${siteParams[amazonSiteId].key}=${encodeURIComponent(siteParams[amazonSiteId].value)}`,
+        `https://www.amazon.${tld}/subcategory/s?${siteParams[amazonSiteId].key}=${encodeURIComponent(siteParams[amazonSiteId].value)}`,
+      ],
+      [
+        "params contain the Amazon seller key-value pair among other values",
+        `https://www.amazon.${tld}/subcategory/s?${siteParams[amazonSiteId].key}=${encodeURIComponent("other," + siteParams[amazonSiteId].value)}`,
+        `https://www.amazon.${tld}/subcategory/s?${siteParams[amazonSiteId].key}=${encodeURIComponent("other," + siteParams[amazonSiteId].value)}`,
+      ],
+      [
+        "params already contain the rh key with a different value",
+        `https://www.amazon.${tld}/subcategory/s?${siteParams[amazonSiteId].key}=other`,
+        `https://www.amazon.${tld}/subcategory/s?${siteParams[amazonSiteId].key}=${encodeURIComponent("other," + siteParams[amazonSiteId].value)}`,
+      ],
+      [
+        "params already contain the rh key with two different values",
+        `https://www.amazon.${tld}/subcategory/s?${siteParams[amazonSiteId].key}=${encodeURIComponent("other1,other2")}`,
+        `https://www.amazon.${tld}/subcategory/s?${siteParams[amazonSiteId].key}=${encodeURIComponent("other1,other2," + siteParams[amazonSiteId].value)}`,
       ],
     ] as const) {
       test(`${amazonSiteId} activating matched: ${name}`, async () => {
-        const resultUrlPrefix = url.endsWith("?") ? url : `${url}?`;
         expect(await generateActivatingUrl(url, builtinSiteData)).toBe(
-          `${resultUrlPrefix}${siteParams[amazonSiteId].key}=${encodeURIComponent(siteParams[amazonSiteId].value)}`,
+          expected,
         );
       });
     }

--- a/src/site_data.ts
+++ b/src/site_data.ts
@@ -16,7 +16,11 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-import { addUrlParam, removeUrlParam } from "./utils";
+import {
+  addUrlParam,
+  addUrlParamCommaSeparated,
+  removeUrlParam,
+} from "./utils";
 
 export interface SiteDataEntry {
   id: string;
@@ -99,7 +103,7 @@ export const builtinSiteData = [
     disablingFunc: (url: string): string | null =>
       removeUrlParam(url, siteParams["Amazon.ca"].key),
     activatingFunc: (url: string): string | null =>
-      addUrlParam(
+      addUrlParamCommaSeparated(
         url,
         siteParams["Amazon.ca"].key,
         siteParams["Amazon.ca"].value,
@@ -112,7 +116,7 @@ export const builtinSiteData = [
     disablingFunc: (url: string): string | null =>
       removeUrlParam(url, siteParams["Amazon.com"].key),
     activatingFunc: (url: string): string | null =>
-      addUrlParam(
+      addUrlParamCommaSeparated(
         url,
         siteParams["Amazon.com"].key,
         siteParams["Amazon.com"].value,
@@ -125,7 +129,7 @@ export const builtinSiteData = [
     disablingFunc: (url: string): string | null =>
       removeUrlParam(url, siteParams["Amazon.co.jp"].key),
     activatingFunc: (url: string): string | null =>
-      addUrlParam(
+      addUrlParamCommaSeparated(
         url,
         siteParams["Amazon.co.jp"].key,
         siteParams["Amazon.co.jp"].value,
@@ -138,7 +142,7 @@ export const builtinSiteData = [
     disablingFunc: (url: string): string | null =>
       removeUrlParam(url, siteParams["Amazon.co.uk"].key),
     activatingFunc: (url: string): string | null =>
-      addUrlParam(
+      addUrlParamCommaSeparated(
         url,
         siteParams["Amazon.co.uk"].key,
         siteParams["Amazon.co.uk"].value,
@@ -151,7 +155,7 @@ export const builtinSiteData = [
     disablingFunc: (url: string): string | null =>
       removeUrlParam(url, siteParams["Amazon.de"].key),
     activatingFunc: (url: string): string | null =>
-      addUrlParam(
+      addUrlParamCommaSeparated(
         url,
         siteParams["Amazon.de"].key,
         siteParams["Amazon.de"].value,
@@ -164,7 +168,7 @@ export const builtinSiteData = [
     disablingFunc: (url: string): string | null =>
       removeUrlParam(url, siteParams["Amazon.es"].key),
     activatingFunc: (url: string): string | null =>
-      addUrlParam(
+      addUrlParamCommaSeparated(
         url,
         siteParams["Amazon.es"].key,
         siteParams["Amazon.es"].value,
@@ -177,7 +181,7 @@ export const builtinSiteData = [
     disablingFunc: (url: string): string | null =>
       removeUrlParam(url, siteParams["Amazon.fr"].key),
     activatingFunc: (url: string): string | null =>
-      addUrlParam(
+      addUrlParamCommaSeparated(
         url,
         siteParams["Amazon.fr"].key,
         siteParams["Amazon.fr"].value,
@@ -190,7 +194,7 @@ export const builtinSiteData = [
     disablingFunc: (url: string): string | null =>
       removeUrlParam(url, siteParams["Amazon.it"].key),
     activatingFunc: (url: string): string | null =>
-      addUrlParam(
+      addUrlParamCommaSeparated(
         url,
         siteParams["Amazon.it"].key,
         siteParams["Amazon.it"].value,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -37,6 +37,37 @@ export function addUrlParam(
   return parsedUrl.toString();
 }
 
+/** Add a param to a URL. if the key already exists, treat the value as
+ * comma-separated and append the specified value.
+ */
+export function addUrlParamCommaSeparated(
+  url: string,
+  paramKey: string,
+  paramValue: string,
+): string | null {
+  const parsedUrl = URL.parse(url);
+
+  // TODO: Impossible to create a case to trigger this part for now. Remove the coverage exception once we can.
+  /* c8 ignore start */
+  if (parsedUrl === null) {
+    // Not a URL.
+    console.error(`${url} is not a URL.`);
+    return null;
+  }
+  /* c8 ignore stop */
+
+  const existingValue = parsedUrl.searchParams.get(paramKey);
+  if (existingValue === null) {
+    return addUrlParam(url, paramKey, paramValue);
+  }
+
+  if (existingValue.split(",").includes(paramValue)) {
+    // No need to change since the param value is already in the value.
+    return url;
+  }
+  return addUrlParam(url, paramKey, `${existingValue},${paramValue}`);
+}
+
 /** Remove a param from a URL. */
 export function removeUrlParam(url: string, paramKey: string): string | null {
   const parsedUrl = URL.parse(url);


### PR DESCRIPTION
Currently, with this extension on, adding other filters on Amazon doesn't take effects. This commit fixes it.

Close #30